### PR TITLE
Deploy only one worker node for cloud-provider-ibmcloud-presubmits

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
                 --build-version $K8S_BUILD_VERSION \
                 --release-marker $K8S_BUILD_VERSION \
                 --cluster-name pull-$TIMESTAMP \
-                --workers-count 2 \
+                --workers-count 1 \
                 --up --down --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true \
                 --powervs-memory 32 \


### PR DESCRIPTION
Reduce the number of worker nodes that are deployed for the optional pre-submit job.